### PR TITLE
Fix change event not bubbling after input set

### DIFF
--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -693,7 +693,7 @@ JS;
             usleep(5000);
 
             try {
-                $this->triggerEvent($xpath, 'change');
+                $this->runScriptOnXpathElement($xpath, 'if (element === document.activeElement) {element.blur();}');
             } catch (ElementNotFoundException $e) {
                 // Ignore, sometimes input elements can get hidden after they are modified.
                 // For example, editing a title inline and sending a newline character at the end


### PR DESCRIPTION
Call blur() on element only if the active element is the same as the one initially operated on.
Lets the browser fire the change event natively rather than faking it.

Address issue https://gitlab.com/DMore/chrome-mink-driver/-/issues/92