### PR TITLE
[BREAKING] rewrite how native browser dialogs are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## Unreleased
+
+* [BREAKING] Rewrite how native dialogs (alert, prompt, confirm, beforeunload) are handled. You must now 
+  register a callback *in advance* to handle any dialog that the browser shows. If you do not explicitly
+  handle the dialog, an UnexpectedJavascriptDialogException will be thrown. 
+
 ## 2.6.4
 
 * Fixed StreamReadException not being caught when browser fails to respond on stop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,17 @@ Changelog
 
 ## Unreleased
 
+## 2.7.0.2 (CUSTOM INGENERATOR RELEASE) (2020-10-29)
+
 * [BREAKING] Rewrite how native dialogs (alert, prompt, confirm, beforeunload) are handled. You must now 
   register a callback *in advance* to handle any dialog that the browser shows. If you do not explicitly
-  handle the dialog, an UnexpectedJavascriptDialogException will be thrown. 
+  handle the dialog, an UnexpectedJavascriptDialogException will be thrown.
+  https://github.com/ingenerator/chrome-mink-driver/pull/4
+
+## 2.7.0.1 (CUSTOM INGENERATOR RELEASE) (2020-10-16)
+
+* Fix change event not bubbling after input value set
+  https://github.com/ingenerator/chrome-mink-driver/pull/3
 
 ## 2.6.4
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+FORKED PROJECT: VERSIONING STRATEGY
+===================================
+
+This is a (possibly temporary) fork of the original dmore/chrome-mink-driver package with some custom additions. To
+avoid complicating version constraints, our releases will track upstream versions, using point releases to mark our
+additions. Therefore **we do not follow semantic versioning**. A version 2.7.0.2 means it's our second modification to
+the upstream 2.7.0. It may well include breaking changes from both 2.7.0 and 2.7.0.1. We consider this acceptable
+because this is test code - by definition any problems it causes are guaranteed to show up during testing before you
+merge the new version to your project.
+
 Chrome Mink Driver
 ==================
 

--- a/src/UnexpectedJavascriptDialogException.php
+++ b/src/UnexpectedJavascriptDialogException.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace DMore\ChromeDriver;
+
+
+use Behat\Mink\Exception\DriverException;
+
+/**
+ * Thrown if the browser presents a native dialog (alert, prompt, etc) and it cannot be handled
+ */
+class UnexpectedJavascriptDialogException extends DriverException
+{
+
+    public function __construct(array $dialog_params, \Throwable $error)
+    {
+        return parent::__construct(
+            sprintf(
+                'Unexpected %s browser dialog: `%s` [%s]',
+                $dialog_params['type'],
+                $dialog_params['message'],
+                $error->getMessage()
+            ),
+            0,
+            $error
+        );
+    }
+
+}

--- a/tests/JavascriptDialogHandlingTest.php
+++ b/tests/JavascriptDialogHandlingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+
+namespace DMore\ChromeDriverTests;
+
+use Behat\Mink\Tests\Driver\TestCase;
+use DMore\ChromeDriver\ChromeDriver;
+use DMore\ChromeDriver\UnexpectedJavascriptDialogException;
+
+class JavascriptDialogHandlingTest extends TestCase
+{
+
+    /**
+     * @testWith ["window.alert('I am alerting you')", "Unexpected alert browser dialog: `I am alerting you`", null]
+     *           ["window.confirm('Launch missiles?')", "Unexpected confirm browser dialog: `Launch missiles?`", false]
+     *           ["window.prompt('Enter launch code')", "Unexpected prompt browser dialog: `Enter launch code`", null]
+     */
+    public function test_it_dismisses_javascript_alert_and_throws_without_handler($js, $expect_msg, $expect_result)
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/index.html'));
+        try {
+            $session->executeScript('window._dialog_result = '.$js);
+            $this->fail('Did not get '.UnexpectedJavascriptDialogException::class);
+        } catch (UnexpectedJavascriptDialogException $e) {
+            $this->assertStringStartsWith($expect_msg, $e->getMessage());
+            $this->assertSame('No javascript dialog handler was registered', $e->getPrevious()->getMessage());
+            // This evaluateScript also ensures that the javascript execution has resumed, odd timeout etc exceptions
+            // most likely mean Chrome is still blocking.
+            $this->assertSame($expect_result, $session->evaluateScript('window._dialog_result'));
+        }
+    }
+
+    public function test_it_dismisses_javascript_alert_and_throws_if_handler_throws()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/index.html'));
+        $handler_exception = new \UnexpectedValueException('I wanted a prompt!');
+        $this->getChromeDriver()->registerJavascriptDialogHandler(
+            function ($dialog_params) use ($handler_exception) { throw $handler_exception; }
+        );
+        try {
+            $session->executeScript(
+                'window._dialog_result = window.confirm("Shall we play Global Thermonuclear War?")'
+            );
+            $this->fail('Did not get '.UnexpectedJavascriptDialogException::class);
+        } catch (UnexpectedJavascriptDialogException $e) {
+            $this->assertStringStartsWith(
+                'Unexpected confirm browser dialog: `Shall we play Global Thermonuclear War?`',
+                $e->getMessage()
+            );
+            $this->assertSame($handler_exception, $e->getPrevious(), 'Attaches previous exception');
+            $this->assertSame(FALSE, $session->evaluateScript('window._dialog_result'));
+        }
+    }
+
+    public function test_it_dismisses_javascript_alert_and_throws_if_handler_does_not_return_instructions()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/index.html'));
+        $this->getChromeDriver()->registerJavascriptDialogHandler(
+            function ($dialog_params) { return []; }
+        );
+        try {
+            $session->executeScript(
+                'window._dialog_result = window.confirm("Shall we play Global Thermonuclear War?")'
+            );
+            $this->fail('Did not get '.UnexpectedJavascriptDialogException::class);
+        } catch (UnexpectedJavascriptDialogException $e) {
+            $this->assertContains('must return an `accept` property', $e->getMessage());
+            $this->assertSame(FALSE, $session->evaluateScript('window._dialog_result'));
+        }
+    }
+
+    /**
+     * @testWith ["window.alert('I am alerting you')", {"accept": false}, {"type": "alert", "message": "I am alerting you"}, null]
+     *           ["window.alert('Bad move')", {"accept": true}, {"type": "alert", "message": "Bad move"}, null]
+     *           ["window.confirm('Thermonuclear War?')", {"accept": false}, {"type": "confirm", "message": "Thermonuclear War?"}, false]
+     *           ["window.confirm('Tic Tac Toe?')", {"accept": true}, {"type": "confirm", "message": "Tic Tac Toe?"}, true]
+     *           ["window.prompt('Launch codes?')", {"accept": false}, {"type": "prompt", "message": "Launch codes?"}, null]
+     *           ["window.prompt('Launch codes?')", {"accept": true, "promptText": "AB9823"}, {"type": "prompt", "message": "Launch codes?"}, "AB9823"]
+     */
+    public function test_it_processes_expected_javascript_dialog_in_line_with_handler_instructions(
+        $js,
+        $handler_return,
+        $expect_called,
+        $expect_result
+    ) {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/index.html'));
+        $handler_calls = [];
+        $this->getChromeDriver()->registerJavascriptDialogHandler(
+            function ($dialog_params) use ($handler_return, &$handler_calls) {
+                $handler_calls[] = $dialog_params;
+
+                return $handler_return;
+            }
+        );
+
+        // This test runs the window.whatever asynchronously so we can prove `wait` works correctly in and around
+        // javascript dialogs being fired. It delays by 10ms to ensure that the wait tries to evaluate at least twice
+        $session->executeScript(
+            'window._dialog_called = false;'
+            .'setTimeout(function () { window._dialog_called = true; window._dialog_result = '.$js.';}, 10);'
+        );
+        $this->assertTrue($session->wait(15, 'window._dialog_called'), 'Wait should succeed');
+        $this->assertSame($expect_result, $session->evaluateScript('window._dialog_result'));
+        $this->assertCount(1, $handler_calls, 'Handler should have been called exactly once');
+        $this->assertArraySubset($expect_called, $handler_calls[0], 'Should have called handler with expected args');
+    }
+
+    protected function getChromeDriver(): ChromeDriver
+    {
+        return $this->getSession()->getDriver();
+    }
+}


### PR DESCRIPTION
Removed the methods to handle dialogs after-the-fact, instead
you must pre-register a callback to handle any dialogs you expect.
Unexpected dialogs will be closed and then an exception thrown.

This ensures that `wait`, `evaluateScript` etc work as expected in
cases where native dialogs are present, without throwing odd
errors about timeouts on the websocket - which are in fact just
because Chrome has paused execution while it waits for a user
interaction with the dialog.