### PR TITLE
Fix PHP8 deprecation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## Unreleased
 
+## 2.7.0.3 (CUSTOM INGENERATOR RELEASE) (2021-10-12)
+
+* Fix PHP8 deprecation warning as optional constructor args can't be before required ones
+
 ## 2.7.0.2 (CUSTOM INGENERATOR RELEASE) (2020-10-29)
 
 * [BREAKING] Rewrite how native dialogs (alert, prompt, confirm, beforeunload) are handled. You must now 

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -49,8 +49,12 @@ class ChromeDriver extends CoreDriver
      * @param $base_url
      * @param array $options
      */
-    public function __construct($api_url = 'http://localhost:9222', HttpClient $http_client = null, $base_url, $options = [])
+    public function __construct($api_url = 'http://localhost:9222', HttpClient $http_client = null, $base_url = null, $options = [])
     {
+        if (empty($base_url)) {
+            throw new \InvalidArgumentException("Base URL can not be empty.");
+        }
+
         if ($http_client == null) {
             $http_client = new HttpClient();
         }


### PR DESCRIPTION
Optional constructor args can't be before required ones