### PR TITLE
Fix handling ConnectionException to get the stream metadata array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## Unreleased
 
+## 2.7.0.5 (CUSTOM INGENERATOR RELEASE) (2021-11-25)
+
+* Update handling of ConnectionException to handle the change to how textalk/websocket provides the stream metadata
+  since v1.5.0 - it no longer json-encodes the stream status in the exception message.
+
 ## 2.7.0.4 (CUSTOM INGENERATOR RELEASE) (2021-11-25)
 
 * Add debugging output to try and understand why we have started getting fatal `Trying to access array offset on value

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require": {
         "ext-curl": "*",
         "ext-json": "*",
-        "textalk/websocket": "^1.2.0",
+        "textalk/websocket": "^1.5.0",
         "behat/mink": "^1.7"
     }
 }

--- a/src/DevToolsConnection.php
+++ b/src/DevToolsConnection.php
@@ -93,21 +93,7 @@ abstract class DevToolsConnection
                     throw $exception;
                 }
 
-                $state = json_decode(substr($message, strpos($message, '{')), true);
-
-                if ( ! \is_array($state)) {
-                    // The driver code appears to assume there'll always be JSON in the message, but we're getting
-                    // 'trying to access array offset on value of type null' which implies either there isn't, or there
-                    // is but it's not valid for some reason.
-                    // Throw with the details so we can try to debug what's going on.
-                    throw new \RuntimeException(
-                        sprintf(
-                            "Unexpected ConnectionException content:\nMessage: `%s`\nJSON state: %s",
-                            $message,
-                            \json_last_error_msg()
-                        )
-                    );
-                }
+                $state = $exception->getData();
 
                 throw new StreamReadException($state['eof'], $state['timed_out'], $state['blocked']);
             }


### PR DESCRIPTION
Since textalk/websocket-php@1449f79fc2b224fe71cf4d06055f41f03ea9b462
the stream metadata is provieded as a property on the exception
itself and is no longer json-encoded within the exception message.

This was causing connection exceptions to have a fatal error
attempting to parse the now-nonexistent-JSON. With luck this will
also allow the existing code in the driver to detect & handle
timeout exceptions properly.