### PR TITLE
Don't fake event timestamps when clicking elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## Unreleased
 
+## 2.7.0.6 (CUSTOM INGENERATOR RELEASE) (2022-02-23)
+
+* Don't fake the timestamps on click events - resolves issues with javascript frameworks ignoring events due to
+  incorrect timestamps.
+
 ## 2.7.0.5 (CUSTOM INGENERATOR RELEASE) (2021-11-25)
 
 * Update handling of ConnectionException to handle the change to how textalk/websocket provides the stream metadata

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -860,7 +860,6 @@ JS;
                     'x' => $left,
                     'y' => $top,
                     'button' => 'left',
-                    'timestamp' => time(),
                     'clickCount' => 1,
                 ];
                 $this->page->send('Input.dispatchMouseEvent', $parameters);
@@ -869,7 +868,6 @@ JS;
                     'x' => $left,
                     'y' => $top,
                     'button' => 'left',
-                    'timestamp' => time(),
                     'clickCount' => 1,
                 ];
                 $this->page->send('Input.dispatchMouseEvent', $parameters);

--- a/tests/ChromeDriverTest.php
+++ b/tests/ChromeDriverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DMore\ChromeDriverTests;
+
+use Behat\Mink\Tests\Driver\TestCase as DriverTestCase;
+
+class ChromeDriverTest extends DriverTestCase
+{
+
+    /**
+     * Check that the timestamp on a click event is a valid / realistic value
+     *
+     * Vuejs and potentially other javascript frameworks use the event.timeStamp to detect (and ignore) events that
+     * were fired before the event listener was attached. For example, if an event causes a new parent element to be
+     * rendered, the event may then bubble to that parent even though the parent was not present in the document when
+     * the event was first dispatched.
+     *
+     * Therefore it's important that event timestamps mirror Chrome's native behaviour and carry the correct
+     * high-performance timestamp for the interaction rather than a simulated value.
+     *
+     * @return void
+     */
+    public function testClickEventTimestamps()
+    {
+        $this->getSession()->visit($this->pathTo('/index.html'));
+        $link = $this->getAssertSession()->elementExists('css', 'a[href="some_url"]');
+
+        $this->getSession()->executeScript(
+            <<<JS
+            (function () {
+              window._test = {
+                listenerAttached: performance.now(),
+                clickedAt: null                
+              }
+              
+              document.querySelector('a[href="some_url"]').addEventListener('click', function (e) {
+                  e.preventDefault();
+                  window._test.clickedAt = e.timeStamp;
+                });
+            })();
+JS
+        );
+
+        $link->click();
+        $result = $this->getSession()->evaluateScript('window._test');
+        $this->assertGreaterThan(
+            $result['listenerAttached'],
+            $result['clickedAt'],
+            'Click event timestamp should be after event listener was attached'
+        );
+    }
+
+}


### PR DESCRIPTION
Previously the driver was sending an integer unix timestamp, which
mirrors old Chrome behaviour. However since Chrome 49 the event
timestamp is a high resolution time relative to the page navigation.
If an integer is passed over devtools protocol, Chrome will attempt
to convert it to the new epoch / type. But this will usually
introduce rounding errors, which often means the event timestamp
is reported as being 500ms or more before the time it was actually
fired.

This then causes issues with front-end code (including vuejs) that
uses the event timestamp to detect various edge cases in event
dispatch with dynamic content. In particular if the event appears
to originate from before an element was rendered / listener was
attached, it may be ignored producing hard-to-debug errors that
cannot be replicated in a real browser.