### PR TITLE
Fix json-encoding value when toggling checkbox

### DIFF
--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -714,7 +714,7 @@ JS;
      */
     private function setNonTextTypeValue($xpath, $value)
     {
-        $json_value = ctype_digit($value) ? $value : json_encode($value);
+        $json_value = (is_string($value) && ctype_digit($value)) ? $value : json_encode($value);
         $text_value = json_encode($value);
         $expression = <<<JS
     var expected_value = $json_value;


### PR DESCRIPTION
ChromeDriver's current implementations need to convert values to JSON to pass into the JS code that actually sets new field values.

Mostly that just means passing to json_encode, but (for cases that I can't currently think of) if the incoming value was a numeric string they skipped that to pass the value across as a raw JSON number  e.g. `123` not `'123'`.

However passing anything other than string to `ctype_digit` is now deprecated. In practice we can just prefix that with is_string, so we get the json-encoded value in every case unless the method was called with a numeric string.

* [ ] attempt to add some tests?