### PR TITLE
Switch back to the main mink driver testsuite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         php_version:
-          - '7.2'
+          - '8.0'
+          - '8.1'
         dependencies:
           - 'default'
 
@@ -26,7 +27,7 @@ jobs:
           /usr/bin/docker run -d -it --rm --name chrome-headless -p 9222:9222 \
           -v $(pwd):/code \
           -e DOCROOT=/code/vendor/mink/driver-testsuite/web-fixtures \
-          registry.gitlab.com/dmore/docker-chrome-headless:7.2 bash
+          registry.gitlab.com/behat-chrome/docker-chrome-headless:${{ matrix.php_version }} bash
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## Unreleased
 
+## 2.7.0.7 (CUSTOM INGENERATOR RELEASE) (2022-10-31)
+
+* Bring in selected changes from upstream package to reintroduce CI & fix support for PHP 8.1. Note the change from
+  urlencode to rawurlencode when setting cookies through the driver (I don't think we actually do this).
+
 ## 2.7.0.6 (CUSTOM INGENERATOR RELEASE) (2022-02-23)
 
 * Don't fake the timestamps on click events - resolves issues with javascript frameworks ignoring events due to

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,4 @@
 {
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/adorin/driver-testsuite.git"
-        }
-    ],
     "name": "ingenerator/chrome-mink-driver",
     "description": "Mink driver for controlling chrome without selenium",
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,9 @@
         "dmore/chrome-mink-driver": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0.0",
-        "mink/driver-testsuite": "dev-master"
+        "phpunit/phpunit": "^9.5",
+        "mink/driver-testsuite": "dev-master",
+        "dms/phpunit-arraysubset-asserts": "^0.4.0"
     },
     "require": {
         "ext-curl": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+    <coverage>
+        <include>
+            <directory>./src/Behat/Mink/Driver</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Driver test suite">
             <directory>tests</directory>
             <directory>vendor/mink/driver-testsuite/tests</directory>
         </testsuite>
     </testsuites>
-
     <php>
-        <server name="WEB_FIXTURES_HOST" value="http://localhost/" />
-        <server name="CHROME_URL" value="http://localhost:9222" />
-        <var name="driver_config_factory" value="DMore\ChromeDriverTests\ChromeDriverConfig::getInstance" />
+        <server name="WEB_FIXTURES_HOST" value="http://localhost/"/>
+        <server name="CHROME_URL" value="http://localhost:9222"/>
+        <var name="driver_config_factory" value="DMore\ChromeDriverTests\ChromeDriverConfig::getInstance"/>
     </php>
-
-    <filter>
-        <whitelist>
-            <directory>./src/Behat/Mink/Driver</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -714,7 +714,7 @@ JS;
      */
     private function setNonTextTypeValue($xpath, $value)
     {
-        $json_value = ctype_digit($value) ? $value : json_encode($value);
+        $json_value = \is_numeric($value) ? $value : json_encode($value);
         $text_value = json_encode($value);
         $expression = <<<JS
     var expected_value = $json_value;

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -277,7 +277,7 @@ class ChromeDriver extends CoreDriver
                 $condition = "window.latest_popup.location.href != 'about:blank';";
                 $this->wait(2000, $condition);
                 $script = "[window.latest_popup.document.title, window.latest_popup.location.href]";
-                list($title, $href) = $this->evaluateScript($script);
+                [$title, $href] = $this->evaluateScript($script);
 
                 foreach ($this->getWindowNames() as $id) {
                     $info = $this->page->send('Target.getTargetInfo', ['targetId' => $id])['targetInfo'];
@@ -382,7 +382,7 @@ JS;
             }
         } else {
             $url = $this->base_url . '/';
-            $value = urlencode($value);
+            $value = rawurlencode($value);
             $this->page->send('Network.setCookie', ['url' => $url, 'name' => $name, 'value' => $value]);
         }
     }
@@ -402,7 +402,7 @@ JS;
 
         foreach ($result['cookies'] as $cookie) {
             if ($cookie['name'] == $name) {
-                return urldecode($cookie['value']);
+                return rawurldecode($cookie['value']);
             }
         }
         return null;
@@ -852,7 +852,7 @@ JS;
             $result = $this->runScriptOnXpathElement($xpath, $script);
 
             if ($result !== null) {
-                list($left, $top) = $result;
+                [$left, $top] = $result;
                 $this->page->send('Input.dispatchMouseEvent', ['type' => 'mouseMoved', 'x' => $left, 'y' => $top]);
 
                 $parameters = [
@@ -964,7 +964,7 @@ JS;
     public function mouseOver($xpath)
     {
         $this->runScriptOnXpathElement($xpath, 'element.scrollIntoViewIfNeeded()');
-        list($left, $top) = $this->getCoordinatesForXpath($xpath);
+        [$left, $top] = $this->getCoordinatesForXpath($xpath);
         $this->page->send('Input.dispatchMouseEvent', ['type' => 'mouseMoved', 'x' => $left + 1, 'y' => $top + 1]);
     }
 
@@ -1013,12 +1013,12 @@ JS;
      */
     public function dragTo($sourceXpath, $destinationXpath)
     {
-        list($left, $top) = $this->getCoordinatesForXpath($sourceXpath);
+        [$left, $top] = $this->getCoordinatesForXpath($sourceXpath);
         $this->page->send('Input.dispatchMouseEvent', ['type' => 'mouseMoved', 'x' => $left + 1, 'y' => $top + 1]);
         $parameters = ['type' => 'mousePressed', 'x' => $left + 1, 'y' => $top + 1, 'button' => 'left'];
         $this->page->send('Input.dispatchMouseEvent', $parameters);
 
-        list($left, $top) = $this->getCoordinatesForXpath($destinationXpath);
+        [$left, $top] = $this->getCoordinatesForXpath($destinationXpath);
         $this->page->send('Input.dispatchMouseEvent', ['type' => 'mouseMoved', 'x' => $left + 1, 'y' => $top + 1]);
         $parameters = ['type' => 'mouseReleased', 'x' => $left + 1, 'y' => $top + 1, 'button' => 'left'];
         $this->page->send('Input.dispatchMouseEvent', $parameters);
@@ -1130,7 +1130,7 @@ JS;
     public function maximizeWindow($name = null)
     {
         if (true === $this->browser->isHeadless()) {
-            list($width, $height) = $this->evaluateScript('[screen.width, screen.height]');
+            [$width, $height] = $this->evaluateScript('[screen.width, screen.height]');
             $this->setVisibleSize($width, $height);
         } else {
             $this->page->send('Browser.setWindowBounds', ['windowId' => 1, 'bounds' => ['windowState' => 'maximized']]);
@@ -1365,7 +1365,7 @@ JS;
     [rect.left, rect.top, rect.width, rect.height]
 JS;
 
-        list($left, $top, $width, $height) = $this->evaluateScript($expression);
+        [$left, $top, $width, $height] = $this->evaluateScript($expression);
         return [ceil($left), ceil($top), floor($width), floor($height)];
     }
 

--- a/tests/JavascriptDialogHandlingTest.php
+++ b/tests/JavascriptDialogHandlingTest.php
@@ -6,6 +6,7 @@ namespace DMore\ChromeDriverTests;
 use Behat\Mink\Tests\Driver\TestCase;
 use DMore\ChromeDriver\ChromeDriver;
 use DMore\ChromeDriver\UnexpectedJavascriptDialogException;
+use DMS\PHPUnitExtensions\ArraySubset\Assert as DMSAssert;
 
 class JavascriptDialogHandlingTest extends TestCase
 {
@@ -67,7 +68,7 @@ class JavascriptDialogHandlingTest extends TestCase
             );
             $this->fail('Did not get '.UnexpectedJavascriptDialogException::class);
         } catch (UnexpectedJavascriptDialogException $e) {
-            $this->assertContains('must return an `accept` property', $e->getMessage());
+            $this->assertStringContainsString('must return an `accept` property', $e->getMessage());
             $this->assertSame(FALSE, $session->evaluateScript('window._dialog_result'));
         }
     }
@@ -106,7 +107,7 @@ class JavascriptDialogHandlingTest extends TestCase
         $this->assertTrue($session->wait(15, 'window._dialog_called'), 'Wait should succeed');
         $this->assertSame($expect_result, $session->evaluateScript('window._dialog_result'));
         $this->assertCount(1, $handler_calls, 'Handler should have been called exactly once');
-        $this->assertArraySubset($expect_called, $handler_calls[0], 'Should have called handler with expected args');
+        DMSAssert::assertArraySubset($expect_called, $handler_calls[0], 'Should have called handler with expected args');
     }
 
     protected function getChromeDriver(): ChromeDriver


### PR DESCRIPTION
At some point, chrome-mink-driver switched to a custom fork of mink/driver-testsuite which is now a long way behind the actual one.

https://github.com/adorin/driver-testsuite/compare/master...minkphp:driver-testsuite:master

As far as I can see, all bar one of the changes in the fork are now in the upstream package, but there are also new tests in upstream which are not being covered on chrome-mink-driver.

I'm curious to see if these newer tests will flush out the issues we have seen in actual CI runs, rather than having to add separate tests for them.