### PR TITLE
Upgrade from textalk/websocket to phrity/websocket

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "textalk/websocket": "^1.5.0",
+        "phrity/websocket": "^1.7",
         "behat/mink": "^1.9"
     }
 }


### PR DESCRIPTION
It appears that phrity/websocket is a maintained fork of the textalk/websocket lib, with better dependency constraints for the future and some PHP8.2 fixes.