### PR TITLE
Initial round of stability fixes updated from the old spike branch

### DIFF
--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -145,7 +145,6 @@ class ChromeDriver extends CoreDriver
         }
 
         if (isset($this->options['validateCertificate']) && $this->options['validateCertificate'] === false) {
-            $this->page->send('Security.enable');
             $this->page->send('Security.setIgnoreCertificateErrors', ['ignore' => true]);
         }
     }

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -189,12 +189,6 @@ class ChromeDriver extends CoreDriver
     {
         try {
             $this->reset();
-            foreach ($this->getWindowNames() as $key => $window_id) {
-                if ($key == 0) {
-                    continue;
-                }
-                $this->http_client->get($this->api_url . '/json/close/' . $window_id);
-            }
             if ($this->page) {
                 $this->page->close();
             }

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -241,8 +241,10 @@ class ChromeDriver extends CoreDriver
         }
         $this->switchToWindow($this->main_window);
         $this->page->reset();
-        $this->request_headers = [];
-        $this->sendRequestHeaders();
+        if ($this->request_headers !== []) {
+            $this->request_headers = [];
+            $this->sendRequestHeaders();
+        }
     }
 
     /**

--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -233,17 +233,66 @@ class ChromeDriver extends CoreDriver
         $this->ensureStarted();
         $this->document = 'document';
         $this->deleteAllCookies();
-        foreach ($this->getWindowNames() as $window_id) {
-            if ($window_id === $this->main_window) {
-                continue;
-            }
-            $this->http_client->get($this->api_url . '/json/close/' . $window_id);
-        }
+        $this->closeWindows(
+            array_filter(
+                $this->getWindowNames(),
+                fn ($window_id) => $window_id !== $this->main_window
+            )
+        );
         $this->switchToWindow($this->main_window);
         $this->page->reset();
         if ($this->request_headers !== []) {
             $this->request_headers = [];
             $this->sendRequestHeaders();
+        }
+    }
+
+    /**
+     * @param list<string> $window_ids
+     *
+     * @throws DriverException if windows do not close within the timeout
+     */
+    private function closeWindows(array $window_ids): void
+    {
+        if ($window_ids === []) {
+            // Nothing to do
+            return;
+        }
+
+        foreach ($window_ids as $id) {
+            $this->http_client->get($this->api_url . '/json/close/' . $id);
+        }
+
+        // Windows close asynchronously and will still be visible in `getWindowNames()` for a moment
+        // after the JSON close command is sent.
+        // Using the JSON API here increases the chance that `->reset()` will succeed even if the
+        // devtools protocol has crashed or is hanging (e.g. if a page has opened a JS dialog, or
+        // failed to load within the timeout).
+
+        // In general, this should take milliseconds, but allow a few seconds for transient slowness.
+        // It is unlikely that this timeout needs to be customised.
+        $timeout = time() + 3;
+
+        while (true) {
+            $open_window_ids = array_map(
+                fn ($w) => $w->id,
+                json_decode($this->http_client->get($this->api_url . '/json/list'))
+            );
+
+            $pending = array_intersect($open_window_ids, $window_ids);
+
+            if ($pending === []) {
+                // All the windows we want to close are now closed
+                return;
+            }
+
+            if (time() > $timeout) {
+                throw new DriverException(
+                    'Timed out waiting to close windows: ' . implode(', ', $pending)
+                );
+            }
+
+            usleep(5000);
         }
     }
 

--- a/src/ChromePage.php
+++ b/src/ChromePage.php
@@ -44,7 +44,6 @@ class ChromePage extends DevToolsConnection
         $this->send('Page.enable');
         $this->send('DOM.enable');
         $this->send('Network.enable');
-        $this->send('Animation.enable');
         $this->send('Animation.setPlaybackRate', ['playbackRate' => 100000]);
         $this->send('Console.enable');
     }
@@ -232,11 +231,6 @@ class ChromePage extends DevToolsConnection
                     break;
                 case 'Inspector.targetCrashed':
                     throw new DriverException('Browser crashed');
-                case 'Animation.animationStarted':
-                    if (!empty($data['params']['source']['duration'])) {
-                        usleep($data['params']['source']['duration'] * 10);
-                    }
-                    break;
                 case 'Security.certificateError':
                     if (isset($data['params']['eventId'])) {
                         $this->send(

--- a/src/ChromePage.php
+++ b/src/ChromePage.php
@@ -231,15 +231,6 @@ class ChromePage extends DevToolsConnection
                     break;
                 case 'Inspector.targetCrashed':
                     throw new DriverException('Browser crashed');
-                case 'Security.certificateError':
-                    if (isset($data['params']['eventId'])) {
-                        $this->send(
-                            'Security.handleCertificateError',
-                            ['eventId' => $data['params']['eventId'], 'action' => 'continue']
-                        );
-                        $this->page_ready = false;
-                    }
-                    break;
                 case 'Console.messageAdded':
                     $this->console_messages[] = $data['params']['message'];
                     break;

--- a/src/DevToolsConnection.php
+++ b/src/DevToolsConnection.php
@@ -147,7 +147,12 @@ abstract class DevToolsConnection
             }
 
             if (is_null($response)) {
-                return null;
+                // There seems to be no valid case where we could actually get an explicit `null` value from the
+                // underlying websocket, other than perhaps the socket being closed by Chrome. Certainly, calling code
+                // (which does not generally check the response) should not blindly continue at this point.
+                throw new DriverException(
+                    'Received unexpected NULL payload from Chrome websocket'
+                );
             }
 
             if ($data = json_decode($response, true)) {


### PR DESCRIPTION
~https://gitlab.com/behat-chrome/chrome-mink-driver/-/merge_requests/188~ was merged, then reverted due to a timing error in tests.

This PR now incorporates https://gitlab.com/behat-chrome/chrome-mink-driver/-/merge_requests/203 and https://gitlab.com/behat-chrome/chrome-mink-driver/-/merge_requests/204