### PR TITLE
Natively flush Chrome localstorage for the domain

### DIFF
--- a/src/ChromeDriver.php
+++ b/src/ChromeDriver.php
@@ -1742,4 +1742,15 @@ JS;
 
         file_put_contents($filename, $imageData);
     }
+
+    public function clearLocalStorageForOrigin(string $origin): void
+    {
+        $this->page->send(
+            'Storage.clearDataForOrigin',
+            [
+                'origin' => $origin,
+                'storageTypes' => 'local_storage',
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Now that the driver always starts on about:blank, it's not possible to use javascript to flush localstorage from a hook because it's not on the right domain.

Fortunately devtools protocol exposes a command for this.

* [ ] needs a test